### PR TITLE
fix for ago / before functions of datejs

### DIFF
--- a/src/sugarpak.js
+++ b/src/sugarpak.js
@@ -446,7 +446,7 @@
         $P[de] = $P[de + "s"] = ef(px[k]);
         
         // Create date element functions and plural date element functions used with Number (eg. day(), days(), months()).
-        $N[de] = $N[de + "s"] = nf(de);
+        $N[de] = $N[de + "s"] = nf(de+"s");
     }
     
     $P._ss = ef("Second");


### PR DESCRIPTION
Hi Eric,

First of all, I'm sorry I can't provide a regression test for the bug this patch is supposed to fix. Neither have I built the script and updated the build/ directory - I have looked and I can't find any instructions on which minifier / macros were used and I don't want to bork things up. If you can help with this then I can give you a much better patch with all the builds fixed as well.

This is a one-line fix (despite appearances in the diff) that fixes the `(6).months().ago()` set of expressions. The reason the fix works is that the `add()` method in `core.js` line 308 expects the plural lowercase form of the duration unit to be set, but without the `+"s"` that I added, sugarpak adds the property as the _singular_ lowercase.

I've made a check of the code and I can't find any other location where the singular is specifically used except in `set`, so I don't believe that this patch should have any side-effects, for example if the inconsistency between singular and plural is a wider problem in the codebase.

Best regards,
- Ian
