### PR TITLE
Invalid UTF-8 character in extras.js

### DIFF
--- a/src/extras.js
+++ b/src/extras.js
@@ -84,7 +84,7 @@
      * Converts the value of the current Date object to its equivalent string representation using a PHP/Unix style of date format specifiers.
      *
      * The following descriptions are from http://www.php.net/strftime and http://www.php.net/manual/en/function.date.php. 
-     * Copyright © 2001-2008 The PHP Group
+     * Copyright (c) 2001-2008 The PHP Group
      * 
      * Format Specifiers
      <pre>


### PR DESCRIPTION
Gives me the following error when minifying/bundling with Sprockets:

```
/home/james/.rvm/gems/ruby-1.9.3-p327/gems/datejs-rails-2.0.0/vendor/assets/javascripts/date/extras.js has a invalid UTF-8 byte sequence
```

This request removes the offending character.
